### PR TITLE
fixed oauth in `mopidy ytmusic setup` command

### DIFF
--- a/mopidy_ytmusic/command.py
+++ b/mopidy_ytmusic/command.py
@@ -17,27 +17,20 @@ class SetupCommand(commands.Command):
     help = "Generate auth.json"
 
     def run(self, args, config):
-        from ytmusicapi import YTMusic
+        from ytmusicapi.setup import setup_oauth
 
         filepath = input(
             "Enter the path where you want to save auth.json [default=current dir]: "
         )
         if not filepath:
             filepath = os.getcwd()
-        path = Path(filepath + "/auth.json")
+        path = Path(filepath + "/oauth.json")
         print('Using "' + str(path) + '"')
         if path.exists():
             print("File already exists!")
             return 1
-        print(
-            "Open Youtube Music, open developer tools (F12), go to Network tab,"
-        )
-        print(
-            'right click on a POST request and choose "Copy request headers".'
-        )
-        print("Then paste (CTRL+SHIFT+V) them here and press CTRL+D.")
         try:
-            print(YTMusic(filepath=str(path)))
+            setup_oauth(filepath=str(path))
         except Exception:
             logger.exception("YTMusic setup failed")
             return 1
@@ -54,7 +47,7 @@ class ReSetupCommand(commands.Command):
     help = "Regenerate auth.json"
 
     def run(self, args, config):
-        from ytmusicapi import YTMusic
+        from ytmusicapi.setup import setup_oauth
 
         path = config["ytmusic"]["auth_json"]
         usingOauth = False

--- a/mopidy_ytmusic/command.py
+++ b/mopidy_ytmusic/command.py
@@ -47,7 +47,7 @@ class ReSetupCommand(commands.Command):
     help = "Regenerate auth.json"
 
     def run(self, args, config):
-        from ytmusicapi.setup import setup_oauth
+        from ytmusicapi import YTMusic
 
         path = config["ytmusic"]["auth_json"]
         usingOauth = False

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ package_data = {"": ["*"]}
 
 install_requires = [
     "Mopidy>=3,<4",
-    "pytube>=12.1.0,<13.0.0",
+    "pytube>=12.1.0",
     "ytmusicapi>=0.22.0,<2.0.0",
 ]
 


### PR DESCRIPTION
The current version of this plugin (with your changes) doesn't work for creating a brand new `auth.json` file - the call for `YTMusic(filepath)` isn't correct anymore - thus, any new user would have issues. This change fixes that issue and `mopidy ytmusic setup` or `sudo mopidyctl ytmusic setup` work fine again creating a correct file. I changed the default name of the file to `oauth.json` to prevent overwriting of the old auth file for people who still have and use it.

Also removed the upper boundary of `pytube` version because it collides with current version `15.0.0` and there are no changes preventing the code from working as is.