### PR TITLE
enable Playlists for oauth login flow

### DIFF
--- a/mopidy_ytmusic/backend.py
+++ b/mopidy_ytmusic/backend.py
@@ -36,7 +36,6 @@ class YTMusicBackend(
         self.audio = audio
         self.uri_schemes = ["ytmusic"]
         self.auth = False
-        self.oauth = False
 
         self._auto_playlist_refresh_rate = (
             config["ytmusic"]["auto_playlist_refresh"] * 60
@@ -58,18 +57,12 @@ class YTMusicBackend(
         self.stream_preference = config["ytmusic"]["stream_preference"]
         self.verify_track_url = config["ytmusic"]["verify_track_url"]
 
-        if config["ytmusic"]["auth_json"]:
-            self._ytmusicapi_auth_json = config["ytmusic"]["auth_json"]
+        if "oauth_json" in config["ytmusic"]:
+            self.api = YTMusic(auth=config["ytmusic"]["oauth_json"])
             self.auth = True
-
-        if config["ytmusic"]["oauth_json"]:
-            self._ytmusicapi_oauth_json = config["ytmusic"]["oauth_json"]
-            self.oauth = True
-
-        if self.auth and not self.oauth:
-            self.api = YTMusic(auth=self._ytmusicapi_auth_json)
-        elif self.oauth:
-            self.api = YTMusic(auth=self._ytmusicapi_oauth_json)
+        elif "auth_json" in config["ytmusic"]:
+            self.api = YTMusic(config["ytmusic"]["auth_json"])
+            self.auth = True
         else:
             self.api = YTMusic()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,16 +13,16 @@ sections = "FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,TESTS,LOCALFOLDER"
 
 [tool.poetry]
 name = "Mopidy-YTMusic"
-version = "0.3.8"
+version = "0.3.9"
 description = "Mopidy extension for playling music/managing playlists in Youtube Music"
 authors = ["Ozymandias (Tomas Ravinskas) <tomas.rav@gmail.com>"]
 license = "Apache-2.0"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.9"
 Mopidy = "^3"
-pytube = "^12.1.0"
-ytmusicapi = ">=0.22.0, <0.30.0"
+pytube = "^15.0.0"
+ytmusicapi = ">=1.0"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.8.4"


### PR DESCRIPTION
Previously user playlists were only loaded for the old cookie authentication. All that needed to be changed was one conditional.