### PR TITLE
Use new library APIs for Auto Playlists and Mood/Genre Playlists

### DIFF
--- a/mopidy_ytmusic/backend.py
+++ b/mopidy_ytmusic/backend.py
@@ -36,7 +36,6 @@ class YTMusicBackend(
         self.audio = audio
         self.uri_schemes = ["ytmusic"]
         self.auth = False
-        self.oauth = False
 
         self._auto_playlist_refresh_rate = (
             config["ytmusic"]["auto_playlist_refresh"] * 60
@@ -58,18 +57,12 @@ class YTMusicBackend(
         self.stream_preference = config["ytmusic"]["stream_preference"]
         self.verify_track_url = config["ytmusic"]["verify_track_url"]
 
-        if config["ytmusic"]["auth_json"]:
-            self._ytmusicapi_auth_json = config["ytmusic"]["auth_json"]
+        if "oauth_json" in config["ytmusic"]:
+            self.api = YTMusic(auth=config["ytmusic"]["oauth_json"])
             self.auth = True
-
-        if config["ytmusic"]["oauth_json"]:
-            self._ytmusicapi_oauth_json = config["ytmusic"]["oauth_json"]
-            self.oauth = True
-
-        if self.auth and not self.oauth:
-            self.api = YTMusic(auth=self._ytmusicapi_auth_json)
-        elif self.oauth:
-            self.api = YTMusic(auth=self._ytmusicapi_oauth_json)
+        elif "auth_json" in config["ytmusic"]:
+            self.api = YTMusic(config["ytmusic"]["auth_json"])
+            self.auth = True
         else:
             self.api = YTMusic()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ["py37", "py38"]
+target-version = ["py38"]
 line-length = 80
 
 [tool.isort]
@@ -13,16 +13,16 @@ sections = "FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,TESTS,LOCALFOLDER"
 
 [tool.poetry]
 name = "Mopidy-YTMusic"
-version = "0.3.8"
+version = "0.3.9"
 description = "Mopidy extension for playling music/managing playlists in Youtube Music"
 authors = ["Ozymandias (Tomas Ravinskas) <tomas.rav@gmail.com>"]
 license = "Apache-2.0"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 Mopidy = "^3"
-pytube = "^12.1.0"
-ytmusicapi = ">=0.22.0, <0.30.0"
+pytube = ">=12.1.0"
+ytmusicapi = ">=1.0"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.8.4"
@@ -30,7 +30,7 @@ setuptools = "^51.0.0"
 Sphinx = "^3.3.1"
 poetry2setup = "^1.0.0"
 isort = "^5"
-black = { version = "*", allow-prereleases = true }
+black = "*"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/setup.py
+++ b/setup.py
@@ -1,34 +1,35 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup
 
-packages = ["mopidy_ytmusic"]
+packages = \
+['mopidy_ytmusic']
 
-package_data = {"": ["*"]}
+package_data = \
+{'': ['*']}
 
-install_requires = [
-    "Mopidy>=3,<4",
-    "pytube>=12.1.0",
-    "ytmusicapi>=0.22.0,<2.0.0",
-]
+install_requires = \
+['Mopidy>=3,<4', 'pytube>=12.1.0', 'ytmusicapi>=1.0']
 
-entry_points = {"mopidy.ext": ["ytmusic = mopidy_ytmusic:Extension"]}
+entry_points = \
+{'mopidy.ext': ['ytmusic = mopidy_ytmusic:Extension']}
 
 setup_kwargs = {
-    "name": "mopidy-ytmusic",
-    "version": "0.3.8",
-    "description": "Mopidy extension for playling music/managing playlists in Youtube Music",
-    "long_description": "None",
-    "author": "Ozymandias (Tomas Ravinskas)",
-    "author_email": "tomas.rav@gmail.com",
-    "maintainer": "None",
-    "maintainer_email": "None",
-    "url": "None",
-    "packages": packages,
-    "package_data": package_data,
-    "install_requires": install_requires,
-    "entry_points": entry_points,
-    "python_requires": ">=3.7,<4.0",
+    'name': 'Mopidy-YTMusic',
+    'version': '0.3.9',
+    'description': 'Mopidy extension for playling music/managing playlists in Youtube Music',
+    'long_description': 'None',
+    'author': 'Ozymandias (Tomas Ravinskas)',
+    'author_email': 'tomas.rav@gmail.com',
+    'maintainer': 'None',
+    'maintainer_email': 'None',
+    'url': 'None',
+    'packages': packages,
+    'package_data': package_data,
+    'install_requires': install_requires,
+    'entry_points': entry_points,
+    'python_requires': '>=3.8,<4.0',
 }
 
 
 setup(**setup_kwargs)
+


### PR DESCRIPTION
Replaces the manual page scraping with `YTMusic.get_home()` for Auto Playlists. For Mood/Genres, `.get_mood_categories()` and `.get_mood_playlists()`.